### PR TITLE
feat(doc): type comment for getConfiguration for autocompletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ To use it:
 - and create the configuration file `kassette.config.js`:
 
 ```javascript
+/**
+ * @return { import("@amadeus-it-group/kassette").ConfigurationSpec }
+ */
 exports.getConfiguration = () => {
   return {
     port: 4200,

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -24,6 +24,9 @@ Table of contents:
 Run `kassette -c kassette.config.js` with `kassette.config.js` file:
 
 ```javascript
+/**
+ * @return { import("@amadeus-it-group/kassette").ConfigurationSpec }
+ */
 exports.getConfiguration = () => {
   return {
     port: 4200,
@@ -52,6 +55,9 @@ Thanks to default behavior it will also:
 Run `kassette -c kassette.config.js` with `kassette.config.js` file:
 
 ```javascript
+/**
+ * @return { import("@amadeus-it-group/kassette").ConfigurationSpec }
+ */
 exports.getConfiguration = () => {
   return {
     port: 4200,
@@ -89,6 +95,9 @@ This will:
 Run `kassette -c kassette.config.js` with `kassette.config.js` file:
 
 ```javascript
+/**
+ * @return { import("@amadeus-it-group/kassette").ConfigurationSpec }
+ */
 exports.getConfiguration = async () => {
   return {
     // default properties for the "mock" instance
@@ -179,6 +188,9 @@ Besides the basic properties already explained for previous use cases, this will
 Run `kassette -c kassette.config.js -p 8000 --folder ./snapshots` with `kassette.config.js` file:
 
 ```javascript
+/**
+ * @return { import("@amadeus-it-group/kassette").ConfigurationSpec }
+ */
 exports.getConfiguration = async () => {
   return {
     // overridden by command line, will be 8000 eventually


### PR DESCRIPTION
As documented in https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#import-types, it is possible to specify the signature of a function in a js comment, including by importing a typescript definition.
This PR adds the correct type in a js comment to all the `getConfiguration` samples in the documentation so that kassette users can have autocompletion in their IDE if they copy/paste the examples.