### PR TITLE
fix: better report header error with JSON.stringify

### DIFF
--- a/packages/app/server/response/impl.ts
+++ b/packages/app/server/response/impl.ts
@@ -111,7 +111,7 @@ export class Response implements IResponse {
           response.setHeader(header.key, header.value!);
         } catch (exception) {
           logError({
-            message: `${CONF.messages.setHeaderError}\n${header.key}: ${header.value}`,
+            message: `${CONF.messages.setHeaderError}\n${JSON.stringify(header)}`,
             exception,
           });
         }


### PR DESCRIPTION
Using `JSON.stringify` better shows unexpected characters in headers. For example the `"\u0001"` character is invalid in a header but, depending on the terminal, it may not be easily visible when displaying it directly in the console, whereas it is always clearly visible when displaying it with `JSON.stringify`.