### PR TITLE
fix(test): e2e code coverage on windows

### DIFF
--- a/packages/rollup.cov.config.js
+++ b/packages/rollup.cov.config.js
@@ -1,11 +1,12 @@
 const fs = require('fs');
+const { normalize } = require('path');
 const { process, shouldInstrument } = require('./instrument');
 
 // override readFileSync to provide instrumented files:
 const trueReadFileSync = fs.readFileSync;
 fs.readFileSync = (...args) => {
   let code = trueReadFileSync(...args);
-  const filename = args[0];
+  const filename = normalize(args[0]);
   if (shouldInstrument(filename)) {
     const isBuffer = Buffer.isBuffer(code);
     if (isBuffer) {


### PR DESCRIPTION
On Windows, it looks like `readFileSync` is called with a path containing forward slashes (instead of the usual backward slashes), and `shouldInstrument` checks that the file path starts with the correct folder (with backward slashes), so no file was instrumented.
Calling `normalize` replaces forward slashes with backward slashes and fixes the issue.