### PR TITLE
fix(test): normalize paths before calling shouldInstrument for coverage (in jest transform)

### DIFF
--- a/packages/jestTransform.js
+++ b/packages/jestTransform.js
@@ -1,13 +1,17 @@
 const { shouldInstrument, process: instrument } = require('./instrument');
 const { createTransformer } = require('ts-jest').default;
+const { normalize } = require('path');
 
 exports.createTransformer = () => {
   const tsJestTransformer = createTransformer();
 
   return {
     process(content, filename, jestConfig) {
-      if (jestConfig.collectCoverage && shouldInstrument(filename)) {
-        content = instrument(content, filename);
+      if (jestConfig.collectCoverage) {
+        const normalizedFileName = normalize(filename);
+        if (shouldInstrument(normalizedFileName)) {
+          content = instrument(content, normalizedFileName);
+        }
       }
       content = tsJestTransformer.process(content, filename, jestConfig);
       return content;


### PR DESCRIPTION
Same as #451 but for jest configuration in case the path is not yet normalized by jest.