### PR TITLE
fix: missing CA option when generating CA certificate

### DIFF
--- a/packages/app/server/tls/impl.ts
+++ b/packages/app/server/tls/impl.ts
@@ -60,6 +60,7 @@ export class TLSManager {
     if (!this._caObject) {
       const ca = await createCertificate(['DO NOT TRUST kassette TLS interception certificate'], {
         keySize: this._config.tlsKeySize,
+        ca: true,
       });
       this._caObject = ca.object;
       this._caPem = ca.cert;
@@ -75,7 +76,6 @@ export class TLSManager {
       res = (async () => {
         const certificate = await createCertificate([host], {
           issuer: this._caObject,
-          ca: false,
           keySize: this._config.tlsKeySize,
         });
         return createSecureContext({


### PR DESCRIPTION
This PR fixes a regression introduced in 1ec84e5708b00b66db1afb4eb6834c62b4d081c0
`ca`, which was the last parameter of the `createCertificate` function, was true by default before that commit, but the default value was lost when refactoring the parameters of `createCertificate` to accept an object.