### PR TITLE
Fix rollup.config.js and rollup.cov.config to be fully commonjs

### DIFF
--- a/packages/rollup.config.js
+++ b/packages/rollup.config.js
@@ -4,7 +4,7 @@ const dependencies = Object.keys(pkg.dependencies);
 const typescript = require('@rollup/plugin-typescript');
 const replace = require('@rollup/plugin-replace');
 
-export default [
+module.exports = [
   {
     output: [
       {

--- a/packages/rollup.cov.config.js
+++ b/packages/rollup.cov.config.js
@@ -20,6 +20,4 @@ fs.readFileSync = (...args) => {
   return code;
 };
 
-import config from './rollup.config';
-
-export default config;
+module.exports = require('./rollup.config');


### PR DESCRIPTION
cf the following failed build when updating rollup:
https://github.com/AmadeusITGroup/kassette/actions/runs/3589679096/jobs/6042341691

> > rimraf ./dist ./build && rollup --failAfterWarnings -c ./packages/rollup.config.js && tsc -p ./packages/tsconfig.dts.json
> 
> (node:1846) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
> (Use `node --trace-warnings ...` to show where the warning was created)
> [!] RollupError: Node tried to load your configuration file as CommonJS even though it is likely an ES module. To resolve this, change the extension of your configuration to ".mjs", set "type": "module" in your package.json file or pass the "--bundleConfigAsCjs" flag.
> 
> Original error: Unexpected token 'export'
> https://rollupjs.org/guide/en/#--bundleconfigascjs
> /home/runner/work/kassette/kassette/packages/rollup.config.js:7
> export default [
> ^^^^^^
> 
> SyntaxError: Unexpected token 'export'
>     at Object.compileFunction (node:vm:360:18)
>     at wrapSafe (node:internal/modules/cjs/loader:1084:15)
>     at Module._compile (node:internal/modules/cjs/loader:1119:27)
>     at Object.Module._extensions..js (node:internal/modules/cjs/loader:1209:10)
>     at Module.load (node:internal/modules/cjs/loader:1033:32)
>     at Function.Module._load (node:internal/modules/cjs/loader:868:12)
>     at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:169:29)
>     at ModuleJob.run (node:internal/modules/esm/module_job:193:25)
>     at async Promise.all (index 0)
>     at ESMLoader.import (node:internal/modules/esm/loader:526:24)
> 
> npm ERR! code 1
> npm ERR! path /home/runner/work/kassette/kassette
> npm ERR! command failed
> npm ERR! command sh -c -- husky install && npm run build && npm run apidoc
> 
> npm ERR! A complete log of this run can be found in:
> npm ERR!     /home/runner/.npm/_logs/2022-12-01T05_06_23_497Z-debug-0.log
> Error: Process completed with exit code 1.
> 