### PR TITLE
test: fixing issue preventing e2e tests from running after updating rimraf

### DIFF
--- a/packages/e2e/orchestrator/index.js
+++ b/packages/e2e/orchestrator/index.js
@@ -1,6 +1,5 @@
 // ------------------------------------------------------------------------- std
 
-const util = require('util');
 const { promises: fs } = require('fs');
 
 // ------------------------------------------------------------------------- 3rd
@@ -58,13 +57,12 @@ function highlightEntity(string) {
 // Workspace reset
 ////////////////////////////////////////////////////////////////////////////////
 
-const rmrf = util.promisify(rimraf);
 async function mkdir(path) {
   return fs.mkdir(path, { recursive: true });
 }
 
 async function resetWorkspace() {
-  await rmrf(PATHS.workspace);
+  await rimraf(PATHS.workspace);
   await mkdir(PATHS.outputs);
   await mkdir(PATHS.resultsFolder);
 }


### PR DESCRIPTION
According to [the readme of rimraf](https://github.com/isaacs/rimraf#major-changes-from-v3-to-v4):
> Major Changes from v3 to v4
> The function returns a Promise instead of taking a callback.

As we were using `rimraf` with `util.promisify`, a callback was passed to `rimraf` and was never called, and the node process was ending successfully because nothing was scheduled to run.