### PR TITLE
chore: adding --ignore-scripts to update commands

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,8 +15,8 @@ jobs:
         with:
           node-version: 16.x
       - run: npx npm-check-updates -u
-      - run: npm install
-      - run: npm update
+      - run: npm install --ignore-scripts
+      - run: npm update --ignore-scripts
       - name: Create pull request
         uses: peter-evans/create-pull-request@bd72e1b7922d417764d27d30768117ad7da78a0e # v4.0.2
         with:


### PR DESCRIPTION
This allows to still open the update PR even if it fails to build.

cf the similar PR on protractor-to-playwright: https://github.com/AmadeusITGroup/protractor-to-playwright/pull/51