### PR TITLE
fix: allow connection to legacy unsafe servers

### DIFF
--- a/packages/app/server/requesting/impl.ts
+++ b/packages/app/server/requesting/impl.ts
@@ -31,6 +31,7 @@ import { Socket } from 'net';
 import { TLSSocket } from 'tls';
 import { SecureClientSessionOptions } from 'http2';
 import { RequestTimings } from '../../../lib/har/harTypes';
+import { constants } from 'crypto';
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -161,6 +162,7 @@ export async function sendRequest({
     // forces the use of http/1.x in case http/1.x is used in the original request:
     ...(original.original?.httpVersionMajor < 2 ? forceHttp1 : {}),
     rejectUnauthorized: false,
+    secureOptions: constants.SSL_OP_LEGACY_SERVER_CONNECT,
     method: requestOptions.method,
     headers: requestOptions.headers,
     agent: {


### PR DESCRIPTION
This PR adds the `SSL_OP_LEGACY_SERVER_CONNECT` flag when connecting to legacy remote servers for increased compatibility.
Note that it allows man-in-the-middle attacks, but those attacks are already possible anyway because of the `rejectUnauthorized` option which allows any certificate on the server. `kassette` is a test tool that is not designed to run in a production environment.

This PR fixes the following error that can happen when this flag is not set:

```
78250000:error:0A000152:SSL routines:final_renegotiate:unsafe legacy renegotiation disabled
```
