### PR TITLE
Feature/single file format option

### DIFF
--- a/packages/app/configuration/model.ts
+++ b/packages/app/configuration/model.ts
@@ -75,7 +75,7 @@ export type Mode =
  *
  * @public
  */
-export type MocksFormat = 'folder' | 'har';
+export type MocksFormat = 'folder' | 'har' | 'filePerRequest';
 
 /**
  * Delay that will be used to send the response to the client

--- a/packages/app/mocking/impl.spec.ts
+++ b/packages/app/mocking/impl.spec.ts
@@ -97,6 +97,55 @@ describe('mocking', () => {
     });
   });
 
+  describe('fileNames', () => {
+    it('should work', () => {
+      const mock = new Mock({
+        options: {
+          root: 'root',
+          userConfiguration: {},
+        },
+        request: {
+          url: { pathname: '/url/path' },
+          method: 'post',
+        },
+      } as any);
+
+      mock.setLocalFileName('mock-file');
+      expect(mock.localFileName).toEqual('mock-file');
+    });
+
+    it('should set local file name to the default', () => {
+      const mock = new Mock({
+        options: {
+          root: 'root',
+          userConfiguration: {},
+        },
+        request: {
+          url: { pathname: '/url/path' },
+          method: 'post',
+        },
+      } as any);
+
+      expect(mock.localFileName).toEqual('request-file');
+    });
+
+    it('should encode the local file name', () => {
+      const mock = new Mock({
+        options: {
+          root: 'root',
+          userConfiguration: {},
+        },
+        request: {
+          url: { pathname: '/url/path' },
+          method: 'post',
+        },
+      } as any);
+
+      mock.setLocalFileName('unsafe>filename<');
+      expect(mock.localFileName).toEqual('unsafe%3Efilename%3C');
+    });
+  });
+
   describe('payloads', () => {
     describe('createPayload', () => {
       it('should work', () => {

--- a/packages/app/mocking/impl.ts
+++ b/packages/app/mocking/impl.ts
@@ -39,6 +39,7 @@ import {
   PayloadWithOrigin,
   Payload,
   RemotePayload,
+  OneFilePerRequestFilePayload,
 } from './model';
 
 import { computeChecksum } from './checksum/impl';
@@ -613,19 +614,29 @@ export class Mock implements IMock {
       payload: { data, body },
     } = payload;
     const dataFile = this._folderFmtFilePerRequest;
-    const allInfo = {
-      request: {
-        headers: this.request.headers,
-        method: this.request.method,
-        url: this.request.url,
-        body: this.request.body.toString(),
-      },
+    let payloadInfo: OneFilePerRequestFilePayload = {
       response: {
         ...data,
       },
       responseBody: body,
     };
-    dataFile.write(stringifyPretty(allInfo));
+    if (this.saveInputRequestData) {
+      payloadInfo = {
+        ...payloadInfo,
+        request: {
+          headers: this.request.headers,
+          method: this.request.method,
+          url: this.request.url,
+        },
+      };
+    }
+    if (this.saveInputRequestBody) {
+      payloadInfo.requestBody = this.request.body.toString();
+    }
+    if (this.saveChecksumContent) {
+      payloadInfo.checksumContent = this.checksumContent;
+    }
+    dataFile.write(stringifyPretty(payloadInfo));
   }
 
   private async _folderFmtPersistPayload(payload: PayloadWithOrigin) {

--- a/packages/app/mocking/impl.ts
+++ b/packages/app/mocking/impl.ts
@@ -100,8 +100,11 @@ export class Mock implements IMock {
   });
 
   private _localFileName = new UserProperty<string, string>({
-    transform: ({ inputOrigin, input }) =>
-      inputOrigin === 'none' || input === undefined ? this.defaultLocalPath : encodeURI(input),
+    transform: ({ inputOrigin, input }) => {
+      return inputOrigin === 'none' || input === undefined
+        ? this.defaultFileName
+        : encodeURI(input);
+    },
   });
 
   private _delay = new UserProperty<Delay, number>({
@@ -356,7 +359,7 @@ export class Mock implements IMock {
     this._localFileName.set(value);
   }
   get localFileName(): string {
-    return this._localPath.output;
+    return this._localFileName.output;
   }
 
   @CachedProperty()

--- a/packages/app/mocking/model.ts
+++ b/packages/app/mocking/model.ts
@@ -268,7 +268,7 @@ export interface IMock {
    * mock.setLocalFileName('input-request')
    * ```
    */
-  setLocalFileName(fileName: string): void
+  setLocalFileName(fileName: string): void;
   /**
    * Returns true if the mock exists locally.
    *
@@ -647,4 +647,33 @@ export interface RemotePayload extends PayloadWithOrigin<'remote'> {
    * Request used to get this remote payload.
    */
   requestOptions: RequestPayload;
+}
+
+/**
+ * The payload that will be saved to the request file
+ * @public
+ */
+export interface OneFilePerRequestFilePayload {
+  /**
+   * Request made.
+   */
+  request?: Object | null;
+  /**
+   * Body of the request made
+   */
+  requestBody?: Object | null;
+  /**
+   * Response data that will be returned
+   * This is a required field
+   */
+  response: Object;
+  /**
+   * Response body that will be returned
+   * This is a required field
+   */
+  responseBody: any;
+  /**
+   * Content produced by the last call to the checksum method, as it was passed to the hash algorithm.
+   */
+  checksumContent?: string | null;
 }

--- a/packages/app/mocking/model.ts
+++ b/packages/app/mocking/model.ts
@@ -176,10 +176,16 @@ export interface IMock {
   setMocksHarKeyManager(value: HarKeyManager | null): void;
 
   /**
-   * Used only when the {@link IMock.mocksFormat|mocks format} is 'folder', specifies the local path of the mock, relative to {@link IMock.mocksFolder|mocksFolder}.
+   * Used when the {@link IMock.mocksFormat|mocks format} is 'folder' and 'filePerRequest', specifies the local path of the mock, relative to {@link IMock.mocksFolder|mocksFolder}.
    * It is either the one set by the user through {@link IMock.setLocalPath|setLocalPath} or {@link IMock.defaultLocalPath|defaultLocalPath}.
    */
   readonly localPath: string;
+
+  /**
+   * Used only when the {@link IMock.mocksFormat|mocks format} is 'filePerRequest', specifies the local file name of the mock, relative to {@link IMock.mocksFolder|mocksFolder}/{@link IMock.localPath|localPath}.
+   * It is either the one set by the user through {@link IMock.setLocalPath|setLocalFileName} or {@link IMock.defaultLocalPath|defaultLocalFileName}.
+   */
+  readonly localFileName: string;
 
   /**
    * Used only when the {@link IMock.mocksFormat|mocks format} is 'folder', specifies the default local path of the mock, relative to {@link IMock.mocksFolder|mocksFolder}, .
@@ -250,6 +256,19 @@ export interface IMock {
    */
   setLocalPath(pathParts: RecursiveArray<string | null | undefined>): void;
 
+  /**
+   * Sets the {@link IMock.localFileName|localFileName} value.
+   *
+   * @param fileName - any combination of  string values to identify a file name
+   * which will eventually be encoded to ensure an OS-safe file name. The file will be stored as JSON.
+   *
+   * @example
+   * The following example will set the file name to input-request
+   * ```
+   * mock.setLocalFileName('input-request')
+   * ```
+   */
+  setLocalFileName(fileName: string): void
   /**
    * Returns true if the mock exists locally.
    *


### PR DESCRIPTION
A new format type has been added, filePerRequest. This type will use json files to save user configurable request/response data. 

A new configuration option has been added to the iMock data type named localFileName and is set by `mock.setLocalFileName`. The file will be saved under the localFileName and in the directory specified by `mock.localPath`.

The format for the request file is json. The data saved in the request file is user configurable set by the `saveChecksumContent`, `saveInputRequestData` etc. user configuration fields.

The response data and body will always be saved as they are required to serve the mock.