### PR TITLE
Provide option to save bodies as JSON objects

### DIFF
--- a/packages/app/configuration/index.spec.ts
+++ b/packages/app/configuration/index.spec.ts
@@ -118,6 +118,7 @@ describe('configuration', () => {
       expect(configuration.onExit.value()).toBeUndefined();
       expect(configuration.hook.value(undefined as any)).toBeUndefined();
       expect(configuration.console.value).toBe(console);
+      expect(configuration.harMimeTypesParseJson.value).toEqual([]);
     });
   });
 });

--- a/packages/app/configuration/index.ts
+++ b/packages/app/configuration/index.ts
@@ -101,6 +101,12 @@ export async function getConfiguration({
       apiValue: apiConfiguration.mocksHarKeyManager,
       defaultValue: defaultHarKeyManager,
     }),
+    harMimeTypesParseJson: buildProperty<Array<string>>({
+      cliValue: cliConfiguration.harMimeTypesParseJson,
+      fileValue: fileConfiguration.harMimeTypesParseJson,
+      apiValue: apiConfiguration.harMimeTypesParseJson,
+      defaultValue: [],
+    }),
     mode: buildProperty<Mode>({
       cliValue: cliConfiguration.mode,
       fileValue: fileConfiguration.mode,

--- a/packages/app/configuration/index.ts
+++ b/packages/app/configuration/index.ts
@@ -102,7 +102,7 @@ export async function getConfiguration({
       defaultValue: defaultHarKeyManager,
     }),
     harMimeTypesParseJson: buildProperty<Array<string>>({
-      cliValue: cliConfiguration.harMimeTypesParseJson,
+      cliValue: [],
       fileValue: fileConfiguration.harMimeTypesParseJson,
       apiValue: apiConfiguration.harMimeTypesParseJson,
       defaultValue: [],

--- a/packages/app/configuration/model.ts
+++ b/packages/app/configuration/model.ts
@@ -342,7 +342,7 @@ export interface CLIConfigurationSpec {
    * Used only when the {@link IMock.mocksFormat|mocks format} is 'har',
    * specifies a list of mime types that will attempt to parse the request/response body as JSON.
    * This will only be applicable to request bodies if {@link IMock.saveInputRequestBody|saveInputRequestBody} is set to true
-   * Default value will be [] and will only be overridden by {@link IMock.setHarSaveParsedJsonBody|setHarSaveParsedJsonBody}
+   * Default value will be [] and will only be overridden by {@link IMock.setHarMimeTypesParseJson|setHarMimeTypesParseJson}
    */
   readonly harMimeTypesParseJson?: string[];
 }

--- a/packages/app/configuration/model.ts
+++ b/packages/app/configuration/model.ts
@@ -337,6 +337,14 @@ export interface CLIConfigurationSpec {
    * Enables http/2.0 protocol in the kassette server.
    */
   readonly http2?: boolean;
+
+  /**
+   * Used only when the {@link IMock.mocksFormat|mocks format} is 'har',
+   * specifies a list of mime types that will attempt to parse the request/response body as JSON.
+   * This will only be applicable to request bodies if {@link IMock.saveInputRequestBody|saveInputRequestBody} is set to true
+   * Default value will be [] and will only be overridden by {@link IMock.setHarSaveParsedJsonBody|setHarSaveParsedJsonBody}
+   */
+  readonly harMimeTypesParseJson?: string[];
 }
 
 /**

--- a/packages/app/configuration/model.ts
+++ b/packages/app/configuration/model.ts
@@ -337,14 +337,6 @@ export interface CLIConfigurationSpec {
    * Enables http/2.0 protocol in the kassette server.
    */
   readonly http2?: boolean;
-
-  /**
-   * Used only when the {@link IMock.mocksFormat|mocks format} is 'har',
-   * specifies a list of mime types that will attempt to parse the request/response body as JSON.
-   * This will only be applicable to request bodies if {@link IMock.saveInputRequestBody|saveInputRequestBody} is set to true
-   * Default value will be [] and will only be overridden by {@link IMock.setHarMimeTypesParseJson|setHarMimeTypesParseJson}
-   */
-  readonly harMimeTypesParseJson?: string[];
 }
 
 /**
@@ -401,6 +393,15 @@ export interface ConfigurationSpec extends CLIConfigurationSpec {
    * Useful to capture the logs of the application.
    */
   readonly console?: ConsoleSpec;
+
+  /**
+   * Used only when the {@link IMock.mocksFormat|mocks format} is 'har',
+   * specifies a list of mime types that will attempt to parse the request/response body as JSON.
+   * If the list includes an empty string: '' and there is no mimeType set in the request, it will attempt to parse the body as JSON.
+   * This will only be applicable to request bodies if {@link IMock.saveInputRequestBody|saveInputRequestBody} is set to true
+   * Default value will be [] and will only be overridden by {@link IMock.setHarMimeTypesParseJson|setHarMimeTypesParseJson}
+   */
+  readonly harMimeTypesParseJson?: string[];
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/packages/app/mocking/impl.spec.ts
+++ b/packages/app/mocking/impl.spec.ts
@@ -146,8 +146,8 @@ describe('mocking', () => {
       });
     });
 
-    describe('saveStringBodies', () => {
-      it('should work', () => {
+    describe('harMimeTypesParseJson', () => {
+      it('should return default and be able to be overridden', () => {
         const mock = new Mock({
           options: {
             root: 'root',
@@ -159,9 +159,8 @@ describe('mocking', () => {
           },
         } as any);
 
-        expect(mock.saveStringBodies).toBe(true);
-        mock.setSaveStringBodies(false);
-        expect(mock.saveStringBodies).toBe(false);
+        mock.setHarMimeTypesParseJson(['application/json']);
+        expect(mock.harMimeTypesParseJson).toEqual(['application/json']);
       });
     });
   });

--- a/packages/app/mocking/impl.spec.ts
+++ b/packages/app/mocking/impl.spec.ts
@@ -147,7 +147,7 @@ describe('mocking', () => {
     });
 
     describe('harMimeTypesParseJson', () => {
-      it('should return default and be able to be overridden', () => {
+      it('should be able to be overridden', () => {
         const mock = new Mock({
           options: {
             root: 'root',
@@ -158,7 +158,6 @@ describe('mocking', () => {
             method: 'post',
           },
         } as any);
-
         mock.setHarMimeTypesParseJson(['application/json']);
         expect(mock.harMimeTypesParseJson).toEqual(['application/json']);
       });

--- a/packages/app/mocking/impl.spec.ts
+++ b/packages/app/mocking/impl.spec.ts
@@ -145,5 +145,24 @@ describe('mocking', () => {
         expect(response.status).toEqual(status);
       });
     });
+
+    describe('saveStringBodies', () => {
+      it('should work', () => {
+        const mock = new Mock({
+          options: {
+            root: 'root',
+            userConfiguration: {},
+          },
+          request: {
+            url: { pathname: '/url/path' },
+            method: 'post',
+          },
+        } as any);
+
+        expect(mock.saveStringBodies).toBe(true);
+        mock.setSaveStringBodies(false);
+        expect(mock.saveStringBodies).toBe(false);
+      });
+    });
   });
 });

--- a/packages/app/mocking/impl.ts
+++ b/packages/app/mocking/impl.ts
@@ -142,9 +142,7 @@ export class Mock implements IMock {
   });
 
   private _harMimeTypesParseJson = new UserProperty<Array<string>>({
-    getDefaultInput: () => {
-      return this.options.userConfiguration.harMimeTypesParseJson.value;
-    },
+    getDefaultInput: () => this.options.userConfiguration.harMimeTypesParseJson.value,
   });
 
   private _mockHarKey = new UserProperty<NonSanitizedArray<string>, string | undefined>({

--- a/packages/app/mocking/impl.ts
+++ b/packages/app/mocking/impl.ts
@@ -805,7 +805,7 @@ export class Mock implements IMock {
         };
         payload = {
           data,
-          body: fromHarContent(entry.response.content),
+          body: fromHarContent(this.saveStringBodies, entry.response.content),
         };
         break;
       }

--- a/packages/app/mocking/impl.ts
+++ b/packages/app/mocking/impl.ts
@@ -576,9 +576,9 @@ export class Mock implements IMock {
   @CachedProperty()
   private get _harFmtPostData(): HarFormatPostData | undefined {
     return toHarPostData(
-      this.harMimeTypesParseJson,
       this.request.body,
       this.request.headers['content-type'],
+      this.harMimeTypesParseJson,
     );
   }
 
@@ -669,7 +669,7 @@ export class Mock implements IMock {
       message: CONF.messages.writingHarFile,
       data: this._harFmtFile.path,
     });
-    const saveParsedJsonBody = this.harMimeTypesParseJson;
+    const harMimeTypesParseJson = this.harMimeTypesParseJson;
     const entry: HarFormatEntry = {
       _kassetteChecksumContent:
         this.saveChecksumContent && this.checksumContent ? this.checksumContent : undefined,
@@ -688,7 +688,7 @@ export class Mock implements IMock {
         cookies: [], // cookies parsing is not implemented
         headersSize: -1,
         bodySize: body?.length ?? 0,
-        content: toHarContent(saveParsedJsonBody, body, data.headers?.['content-type']),
+        content: toHarContent(body, data.headers?.['content-type'], harMimeTypesParseJson),
       },
     };
     if (this.saveInputRequestData) {
@@ -718,9 +718,9 @@ export class Mock implements IMock {
           entry._kassetteForwardedRequest = {};
         }
         entry._kassetteForwardedRequest.postData = toHarPostData(
-          this.harMimeTypesParseJson,
           payload.requestOptions.body,
           payload.requestOptions.headers['content-type'],
+          this.harMimeTypesParseJson,
         );
       }
     }

--- a/packages/app/mocking/impl.ts
+++ b/packages/app/mocking/impl.ts
@@ -141,10 +141,10 @@ export class Mock implements IMock {
     getDefaultInput: () => this.options.userConfiguration.mocksHarKeyManager.value,
   });
 
-  private _saveStringBodies = new UserProperty<boolean>({
-    getDefaultInput: () => true,
-    transform: ({ inputOrigin, input }) =>
-      inputOrigin === 'none' || input === undefined ? true : input,
+  private _harMimeTypesParseJson = new UserProperty<Array<string>>({
+    getDefaultInput: () => {
+      return this.options.userConfiguration.harMimeTypesParseJson.value;
+    },
   });
 
   private _mockHarKey = new UserProperty<NonSanitizedArray<string>, string | undefined>({
@@ -342,11 +342,11 @@ export class Mock implements IMock {
     this._setUserProperty(this._skipLog, value);
   }
 
-  public get saveStringBodies(): boolean {
-    return this._saveStringBodies.output;
+  public get harMimeTypesParseJson(): string[] {
+    return this._harMimeTypesParseJson.output;
   }
-  public setSaveStringBodies(value: boolean): void {
-    this._setUserProperty(this._saveStringBodies, value);
+  public setHarMimeTypesParseJson(value: string[]): void {
+    this._setUserProperty(this._harMimeTypesParseJson, value);
   }
 
   //////////////////////////////////////////////////////////////////////////////
@@ -578,7 +578,7 @@ export class Mock implements IMock {
   @CachedProperty()
   private get _harFmtPostData(): HarFormatPostData | undefined {
     return toHarPostData(
-      this.saveStringBodies,
+      this.harMimeTypesParseJson,
       this.request.body,
       this.request.headers['content-type'],
     );
@@ -671,7 +671,7 @@ export class Mock implements IMock {
       message: CONF.messages.writingHarFile,
       data: this._harFmtFile.path,
     });
-    const saveBodiesAsString = this.saveStringBodies;
+    const saveParsedJsonBody = this.harMimeTypesParseJson;
     const entry: HarFormatEntry = {
       _kassetteChecksumContent:
         this.saveChecksumContent && this.checksumContent ? this.checksumContent : undefined,
@@ -690,7 +690,7 @@ export class Mock implements IMock {
         cookies: [], // cookies parsing is not implemented
         headersSize: -1,
         bodySize: body?.length ?? 0,
-        content: toHarContent(saveBodiesAsString, body, data.headers?.['content-type']),
+        content: toHarContent(saveParsedJsonBody, body, data.headers?.['content-type']),
       },
     };
     if (this.saveInputRequestData) {
@@ -720,7 +720,7 @@ export class Mock implements IMock {
           entry._kassetteForwardedRequest = {};
         }
         entry._kassetteForwardedRequest.postData = toHarPostData(
-          this.saveStringBodies,
+          this.harMimeTypesParseJson,
           payload.requestOptions.body,
           payload.requestOptions.headers['content-type'],
         );
@@ -805,7 +805,7 @@ export class Mock implements IMock {
         };
         payload = {
           data,
-          body: fromHarContent(this.saveStringBodies, entry.response.content),
+          body: fromHarContent(entry.response.content),
         };
         break;
       }

--- a/packages/app/mocking/model.ts
+++ b/packages/app/mocking/model.ts
@@ -179,7 +179,7 @@ export interface IMock {
    * Used only when the {@link IMock.mocksFormat|mocks format} is 'har',
    * specifies a list of mime types that will attempt to parse the request/response body as JSON.
    * This will only be applicable to request bodies if {@link IMock.saveInputRequestBody|saveInputRequestBody} is set to true
-   * Default value will be [] and will only be overridden by {@link IMock.setHarSaveParsedJsonBody|setHarSaveParsedJsonBody}
+   * Default value will be [] and will only be overridden by {@link IMock.setHarMimeTypesParseJson|setHarMimeTypesParseJson}
    */
   readonly harMimeTypesParseJson: string[];
 

--- a/packages/app/mocking/model.ts
+++ b/packages/app/mocking/model.ts
@@ -176,6 +176,21 @@ export interface IMock {
   setMocksHarKeyManager(value: HarKeyManager | null): void;
 
   /**
+   * Used only when the {@link IMock.mocksFormat|mocks format} is 'har',
+   * specifies if the request and response bodies should be saved as JSON objects or as strings.
+   * This will only be applicable to request bodies if {@link IMock.saveInputRequestBody|saveInputRequestBody} is set to true
+   * Default value will be true and will only be overridden by {@link IMock.setSaveStringBodies|setSaveStringBodies}
+   */
+  readonly saveStringBodies: boolean;
+
+  /**
+   * Sets the {@link IMock.saveBodiesAsJson|saveBodiesAsJson} value.
+   *
+   * @param value - whether the request and response bodies should be saved as strings
+   */
+  setSaveStringBodies(value: boolean): void;
+
+  /**
    * Used only when the {@link IMock.mocksFormat|mocks format} is 'folder', specifies the local path of the mock, relative to {@link IMock.mocksFolder|mocksFolder}.
    * It is either the one set by the user through {@link IMock.setLocalPath|setLocalPath} or {@link IMock.defaultLocalPath|defaultLocalPath}.
    */

--- a/packages/app/mocking/model.ts
+++ b/packages/app/mocking/model.ts
@@ -177,18 +177,18 @@ export interface IMock {
 
   /**
    * Used only when the {@link IMock.mocksFormat|mocks format} is 'har',
-   * specifies if the request and response bodies should be saved as JSON objects or as strings.
+   * specifies a list of mime types that will attempt to parse the request/response body as JSON.
    * This will only be applicable to request bodies if {@link IMock.saveInputRequestBody|saveInputRequestBody} is set to true
-   * Default value will be true and will only be overridden by {@link IMock.setSaveStringBodies|setSaveStringBodies}
+   * Default value will be [] and will only be overridden by {@link IMock.setHarSaveParsedJsonBody|setHarSaveParsedJsonBody}
    */
-  readonly saveStringBodies: boolean;
+  readonly harMimeTypesParseJson: string[];
 
   /**
-   * Sets the {@link IMock.saveBodiesAsJson|saveBodiesAsJson} value.
+   * Sets the {@link IMock.harMimeTypesParseJson|harMimeTypesParseJson} value.
    *
-   * @param value - whether the request and response bodies should be saved as strings
+   * @param value - The mime types that should attempt to parse the body as json
    */
-  setSaveStringBodies(value: boolean): void;
+  setHarMimeTypesParseJson(value: string[]): void;
 
   /**
    * Used only when the {@link IMock.mocksFormat|mocks format} is 'folder', specifies the local path of the mock, relative to {@link IMock.mocksFolder|mocksFolder}.

--- a/packages/app/server/configuration/index.spec.ts
+++ b/packages/app/server/configuration/index.spec.ts
@@ -115,6 +115,7 @@ describe('server configuration', () => {
           saveInputRequestBody: { value: true, origin: 'default' },
           saveForwardedRequestData: { value: true, origin: 'default' },
           saveForwardedRequestBody: { value: true, origin: 'default' },
+          harMimeTypesParseJson: { value: [], origin: 'default' },
         },
       });
 
@@ -183,6 +184,7 @@ Root folder used for relative paths resolution: ${highlighted('C:/dummy/root/fol
           saveInputRequestBody: { value: true, origin: 'default' },
           saveForwardedRequestData: { value: true, origin: 'default' },
           saveForwardedRequestBody: { value: true, origin: 'default' },
+          harMimeTypesParseJson: { value: [], origin: 'default' },
         },
       });
 

--- a/packages/lib/har/harTypes.ts
+++ b/packages/lib/har/harTypes.ts
@@ -323,6 +323,11 @@ export interface HarFormatPostData {
    * Any comment as a string. This is not used by kassette.
    */
   comment?: string;
+
+  /**
+   * Response body saved as an object.
+   */
+  json?: any;
 }
 
 /**
@@ -353,7 +358,7 @@ export interface HarFormatContent {
    *
    * The response body can be encoded in base64 if this is specified in the {@link HarFormatContent.encoding | encoding} field.
    */
-  text?: any;
+  text?: string;
 
   /**
    * Encoding used for the {@link HarFormatContent.text | text} field, such as "base64".
@@ -364,6 +369,11 @@ export interface HarFormatContent {
    * Any comment as a string. This is not used by kassette.
    */
   comment?: string;
+
+  /**
+   * Response body saved as an object.
+   */
+  json?: any;
 }
 
 /**

--- a/packages/lib/har/harTypes.ts
+++ b/packages/lib/har/harTypes.ts
@@ -353,7 +353,7 @@ export interface HarFormatContent {
    *
    * The response body can be encoded in base64 if this is specified in the {@link HarFormatContent.encoding | encoding} field.
    */
-  text?: string;
+  text?: any;
 
   /**
    * Encoding used for the {@link HarFormatContent.text | text} field, such as "base64".

--- a/packages/lib/har/harUtils.spec.ts
+++ b/packages/lib/har/harUtils.spec.ts
@@ -9,6 +9,7 @@ import {
   toHarHttpVersion,
   toHarPostData,
   toHarQueryString,
+  checkMimeTypeListAndParseBody,
 } from './harUtils';
 
 describe('harUtils', () => {
@@ -241,6 +242,30 @@ describe('harUtils', () => {
         json: content,
       });
       expect(buffer.equals(returned)).toBeTruthy();
+    });
+  });
+
+  describe('checkMimeTypeListAndParseBody', () => {
+    it('should return text if cant parse JSON', () => {
+      const content = 'Hello!';
+      const returned = checkMimeTypeListAndParseBody(
+        ['application/json'],
+        content,
+        'application/json',
+      );
+      expect(returned).toEqual({
+        mimeType: 'application/json',
+        text: content,
+      });
+    });
+
+    it('should parse json if no mimeType is passed and mimeTypeList contains empty string', () => {
+      const content = '{"test": "hello"}';
+      const returned = checkMimeTypeListAndParseBody([''], content);
+      expect(returned).toEqual({
+        mimeType: undefined,
+        json: { test: 'hello' },
+      });
     });
   });
 

--- a/packages/lib/har/harUtils.spec.ts
+++ b/packages/lib/har/harUtils.spec.ts
@@ -120,7 +120,7 @@ describe('harUtils', () => {
         size: 25,
         encoding: 'base64',
         text: content,
-      }) as Buffer;
+      });
       expect(buffer.equals(outputBuffer)).toBeTruthy();
     });
 
@@ -151,7 +151,7 @@ describe('harUtils', () => {
         mimeType: 'text/plain',
         size: 6,
         text: content,
-      }) as Buffer;
+      });
       expect(buffer.equals(outputBuffer)).toBeTruthy();
     });
 

--- a/packages/lib/har/harUtils.spec.ts
+++ b/packages/lib/har/harUtils.spec.ts
@@ -90,7 +90,7 @@ describe('harUtils', () => {
   describe('content', () => {
     it('should work with empty content', () => {
       expect(toHarContent(true, null)).toEqual({ mimeType: '', size: 0, text: '' });
-      const emptyBuffer = fromHarContent({});
+      const emptyBuffer = fromHarContent(true, {});
       expect(Buffer.isBuffer(emptyBuffer)).toBeTruthy();
       expect(emptyBuffer.length).toBe(0);
     });
@@ -113,12 +113,12 @@ describe('harUtils', () => {
         encoding: 'base64',
         text: content,
       });
-      const outputBuffer = fromHarContent({
+      const outputBuffer = fromHarContent(true, {
         mimeType: 'application/octet-stream',
         size: 25,
         encoding: 'base64',
         text: content,
-      });
+      }) as Buffer;
       expect(buffer.equals(outputBuffer)).toBeTruthy();
     });
 
@@ -145,11 +145,11 @@ describe('harUtils', () => {
         size: 6,
         text: content,
       });
-      const outputBuffer = fromHarContent({
+      const outputBuffer = fromHarContent(true, {
         mimeType: 'text/plain',
         size: 6,
         text: content,
-      });
+      }) as Buffer;
       expect(buffer.equals(outputBuffer)).toBeTruthy();
     });
 
@@ -231,6 +231,29 @@ describe('harUtils', () => {
         mimeType: 'application/json',
         text: content,
       });
+    });
+  });
+
+  describe('fromHarContent', () => {
+    it('should return content if saveStringBodies is false', () => {
+      const content = { test: 'hello' };
+      const returned = fromHarContent(false, {
+        mimeType: 'application/json',
+        size: 17,
+        text: content,
+      });
+      expect(returned).toEqual(content);
+    });
+
+    it('should convert from a buffer if saveStringBodies is true ', () => {
+      const content = '{"test": "hello"}';
+      const buffer = Buffer.from(content, 'utf8');
+      const returned = fromHarContent(true, {
+        mimeType: 'application/json',
+        size: 17,
+        text: buffer,
+      });
+      expect(buffer.equals(returned)).toBeTruthy();
     });
   });
 

--- a/packages/lib/har/harUtils.spec.ts
+++ b/packages/lib/har/harUtils.spec.ts
@@ -89,7 +89,7 @@ describe('harUtils', () => {
 
   describe('content', () => {
     it('should work with empty content', () => {
-      expect(toHarContent(null)).toEqual({ mimeType: '', size: 0, text: '' });
+      expect(toHarContent(true, null)).toEqual({ mimeType: '', size: 0, text: '' });
       const emptyBuffer = fromHarContent({});
       expect(Buffer.isBuffer(emptyBuffer)).toBeTruthy();
       expect(emptyBuffer.length).toBe(0);
@@ -101,13 +101,13 @@ describe('harUtils', () => {
         'hex',
       ).toString('base64');
       const buffer = Buffer.from(content, 'base64');
-      expect(toHarContent(buffer, 'application/octet-stream')).toEqual({
+      expect(toHarContent(true, buffer, 'application/octet-stream')).toEqual({
         mimeType: 'application/octet-stream',
         size: 25,
         encoding: 'base64',
         text: content,
       });
-      expect(toHarContent(buffer)).toEqual({
+      expect(toHarContent(true, buffer)).toEqual({
         mimeType: '',
         size: 25,
         encoding: 'base64',
@@ -125,22 +125,22 @@ describe('harUtils', () => {
     it('should work with text content', () => {
       const content = 'Hello!';
       const buffer = Buffer.from(content, 'utf8');
-      expect(toHarContent(buffer, 'text/plain')).toEqual({
+      expect(toHarContent(true, buffer, 'text/plain')).toEqual({
         mimeType: 'text/plain',
         size: 6,
         text: content,
       });
-      expect(toHarContent(buffer)).toEqual({
+      expect(toHarContent(true, buffer)).toEqual({
         mimeType: '',
         size: 6,
         text: content,
       });
-      expect(toHarContent(content, 'text/plain')).toEqual({
+      expect(toHarContent(true, content, 'text/plain')).toEqual({
         mimeType: 'text/plain',
         size: 6,
         text: content,
       });
-      expect(toHarContent(content)).toEqual({
+      expect(toHarContent(true, content)).toEqual({
         mimeType: '',
         size: 6,
         text: content,
@@ -152,16 +152,46 @@ describe('harUtils', () => {
       });
       expect(buffer.equals(outputBuffer)).toBeTruthy();
     });
+
+    it('should parse json data', () => {
+      const content = '{"test": "hello"}';
+      const buffer = Buffer.from(content, 'utf8');
+      expect(toHarContent(false, buffer, 'application/json')).toEqual({
+        mimeType: 'application/json',
+        size: 17,
+        text: { test: 'hello' },
+      });
+    });
+
+    it('should not parse json data when mimeType is not application/json', () => {
+      const content = '{"test": "hello"}';
+      const buffer = Buffer.from(content, 'utf8');
+      expect(toHarContent(false, buffer, 'text/plain')).toEqual({
+        mimeType: 'text/plain',
+        size: 17,
+        text: content,
+      });
+    });
+
+    it('should not parse json data when saveAsString is true', () => {
+      const content = '{"test": "hello"}';
+      const buffer = Buffer.from(content, 'utf8');
+      expect(toHarContent(true, buffer, 'text/plain')).toEqual({
+        mimeType: 'text/plain',
+        size: 17,
+        text: content,
+      });
+    });
   });
 
   describe('postData', () => {
     it('should work with no data', () => {
-      expect(toHarPostData(Buffer.alloc(0))).toBe(undefined);
+      expect(toHarPostData(true, Buffer.alloc(0))).toBe(undefined);
     });
 
     it('should work with binary data', () => {
       const buffer = Buffer.from('000102030405060708090a0b0c0d0e0f414243444546474849', 'hex');
-      expect(toHarPostData(buffer, 'application/octet-stream')).toEqual({
+      expect(toHarPostData(true, buffer, 'application/octet-stream')).toEqual({
         mimeType: 'application/octet-stream',
         text: buffer.toString('binary'),
       });
@@ -169,12 +199,36 @@ describe('harUtils', () => {
 
     it('should work with text data', () => {
       const content = 'Hello!';
-      expect(toHarPostData(Buffer.from(content, 'utf8'), 'text/plain')).toEqual({
+      expect(toHarPostData(true, Buffer.from(content, 'utf8'), 'text/plain')).toEqual({
         mimeType: 'text/plain',
         text: content,
       });
-      expect(toHarPostData(content, 'text/plain')).toEqual({
+      expect(toHarPostData(true, content, 'text/plain')).toEqual({
         mimeType: 'text/plain',
+        text: content,
+      });
+    });
+
+    it('should parse json data', () => {
+      const content = '{"test": "hello"}';
+      expect(toHarPostData(false, Buffer.from(content, 'utf8'), 'application/json')).toEqual({
+        mimeType: 'application/json',
+        text: { test: 'hello' },
+      });
+    });
+
+    it('should not parse json data when mimeType is not application/json', () => {
+      const content = '{"test": "hello"}';
+      expect(toHarPostData(false, Buffer.from(content, 'utf8'), 'text/plain')).toEqual({
+        mimeType: 'text/plain',
+        text: content,
+      });
+    });
+
+    it('should not parse json data when saveAsString is true', () => {
+      const content = '{"test": "hello"}';
+      expect(toHarPostData(true, Buffer.from(content, 'utf8'), 'application/json')).toEqual({
+        mimeType: 'application/json',
         text: content,
       });
     });

--- a/packages/lib/har/harUtils.spec.ts
+++ b/packages/lib/har/harUtils.spec.ts
@@ -89,8 +89,8 @@ describe('harUtils', () => {
 
   describe('content', () => {
     it('should work with empty content', () => {
-      expect(toHarContent(true, null)).toEqual({ mimeType: '', size: 0, text: '' });
-      const emptyBuffer = fromHarContent(true, {});
+      expect(toHarContent([], null)).toEqual({ mimeType: '', size: 0, text: '' });
+      const emptyBuffer = fromHarContent({});
       expect(Buffer.isBuffer(emptyBuffer)).toBeTruthy();
       expect(emptyBuffer.length).toBe(0);
     });
@@ -101,19 +101,19 @@ describe('harUtils', () => {
         'hex',
       ).toString('base64');
       const buffer = Buffer.from(content, 'base64');
-      expect(toHarContent(true, buffer, 'application/octet-stream')).toEqual({
+      expect(toHarContent([], buffer, 'application/octet-stream')).toEqual({
         mimeType: 'application/octet-stream',
         size: 25,
         encoding: 'base64',
         text: content,
       });
-      expect(toHarContent(true, buffer)).toEqual({
+      expect(toHarContent([], buffer)).toEqual({
         mimeType: '',
         size: 25,
         encoding: 'base64',
         text: content,
       });
-      const outputBuffer = fromHarContent(true, {
+      const outputBuffer = fromHarContent({
         mimeType: 'application/octet-stream',
         size: 25,
         encoding: 'base64',
@@ -125,27 +125,27 @@ describe('harUtils', () => {
     it('should work with text content', () => {
       const content = 'Hello!';
       const buffer = Buffer.from(content, 'utf8');
-      expect(toHarContent(true, buffer, 'text/plain')).toEqual({
+      expect(toHarContent([], buffer, 'text/plain')).toEqual({
         mimeType: 'text/plain',
         size: 6,
         text: content,
       });
-      expect(toHarContent(true, buffer)).toEqual({
+      expect(toHarContent([], buffer)).toEqual({
         mimeType: '',
         size: 6,
         text: content,
       });
-      expect(toHarContent(true, content, 'text/plain')).toEqual({
+      expect(toHarContent([], content, 'text/plain')).toEqual({
         mimeType: 'text/plain',
         size: 6,
         text: content,
       });
-      expect(toHarContent(true, content)).toEqual({
+      expect(toHarContent([], content)).toEqual({
         mimeType: '',
         size: 6,
         text: content,
       });
-      const outputBuffer = fromHarContent(true, {
+      const outputBuffer = fromHarContent({
         mimeType: 'text/plain',
         size: 6,
         text: content,
@@ -156,17 +156,17 @@ describe('harUtils', () => {
     it('should parse json data', () => {
       const content = '{"test": "hello"}';
       const buffer = Buffer.from(content, 'utf8');
-      expect(toHarContent(false, buffer, 'application/json')).toEqual({
+      expect(toHarContent(['application/json'], buffer, 'application/json')).toEqual({
         mimeType: 'application/json',
         size: 17,
-        text: { test: 'hello' },
+        json: { test: 'hello' },
       });
     });
 
     it('should not parse json data when mimeType is not application/json', () => {
       const content = '{"test": "hello"}';
       const buffer = Buffer.from(content, 'utf8');
-      expect(toHarContent(false, buffer, 'text/plain')).toEqual({
+      expect(toHarContent(['application/json'], buffer, 'text/plain')).toEqual({
         mimeType: 'text/plain',
         size: 17,
         text: content,
@@ -176,7 +176,7 @@ describe('harUtils', () => {
     it('should not parse json data when saveAsString is true', () => {
       const content = '{"test": "hello"}';
       const buffer = Buffer.from(content, 'utf8');
-      expect(toHarContent(true, buffer, 'text/plain')).toEqual({
+      expect(toHarContent([], buffer, 'text/plain')).toEqual({
         mimeType: 'text/plain',
         size: 17,
         text: content,
@@ -186,12 +186,12 @@ describe('harUtils', () => {
 
   describe('postData', () => {
     it('should work with no data', () => {
-      expect(toHarPostData(true, Buffer.alloc(0))).toBe(undefined);
+      expect(toHarPostData([], Buffer.alloc(0))).toBe(undefined);
     });
 
     it('should work with binary data', () => {
       const buffer = Buffer.from('000102030405060708090a0b0c0d0e0f414243444546474849', 'hex');
-      expect(toHarPostData(true, buffer, 'application/octet-stream')).toEqual({
+      expect(toHarPostData([], buffer, 'application/octet-stream')).toEqual({
         mimeType: 'application/octet-stream',
         text: buffer.toString('binary'),
       });
@@ -199,11 +199,11 @@ describe('harUtils', () => {
 
     it('should work with text data', () => {
       const content = 'Hello!';
-      expect(toHarPostData(true, Buffer.from(content, 'utf8'), 'text/plain')).toEqual({
+      expect(toHarPostData([], Buffer.from(content, 'utf8'), 'text/plain')).toEqual({
         mimeType: 'text/plain',
         text: content,
       });
-      expect(toHarPostData(true, content, 'text/plain')).toEqual({
+      expect(toHarPostData([], content, 'text/plain')).toEqual({
         mimeType: 'text/plain',
         text: content,
       });
@@ -211,49 +211,34 @@ describe('harUtils', () => {
 
     it('should parse json data', () => {
       const content = '{"test": "hello"}';
-      expect(toHarPostData(false, Buffer.from(content, 'utf8'), 'application/json')).toEqual({
+      expect(
+        toHarPostData(['application/json'], Buffer.from(content, 'utf8'), 'application/json'),
+      ).toEqual({
         mimeType: 'application/json',
-        text: { test: 'hello' },
+        json: { test: 'hello' },
       });
     });
 
     it('should not parse json data when mimeType is not application/json', () => {
       const content = '{"test": "hello"}';
-      expect(toHarPostData(false, Buffer.from(content, 'utf8'), 'text/plain')).toEqual({
+      expect(
+        toHarPostData(['application/json'], Buffer.from(content, 'utf8'), 'text/plain'),
+      ).toEqual({
         mimeType: 'text/plain',
-        text: content,
-      });
-    });
-
-    it('should not parse json data when saveAsString is true', () => {
-      const content = '{"test": "hello"}';
-      expect(toHarPostData(true, Buffer.from(content, 'utf8'), 'application/json')).toEqual({
-        mimeType: 'application/json',
         text: content,
       });
     });
   });
 
   describe('fromHarContent', () => {
-    it('should return content if saveStringBodies is false', () => {
+    it('should return content if json is set', () => {
       const content = { test: 'hello' };
-      const returned = fromHarContent(false, {
+      const returned = fromHarContent({
         mimeType: 'application/json',
         size: 17,
-        text: content,
+        json: content,
       });
       expect(returned).toEqual(content);
-    });
-
-    it('should convert from a buffer if saveStringBodies is true ', () => {
-      const content = '{"test": "hello"}';
-      const buffer = Buffer.from(content, 'utf8');
-      const returned = fromHarContent(true, {
-        mimeType: 'application/json',
-        size: 17,
-        text: buffer,
-      });
-      expect(buffer.equals(returned)).toBeTruthy();
     });
   });
 

--- a/packages/lib/har/harUtils.ts
+++ b/packages/lib/har/harUtils.ts
@@ -95,8 +95,11 @@ export const toHarContent = (
   };
 };
 
-export const fromHarContent = (content?: HarFormatContent) => {
+export const fromHarContent = (saveAsString: boolean, content?: HarFormatContent) => {
   if (content?.text) {
+    if (!saveAsString) {
+      return content.text;
+    }
     return Buffer.from(content.text, content.encoding === 'base64' ? 'base64' : 'binary');
   }
   return Buffer.alloc(0);

--- a/packages/lib/har/harUtils.ts
+++ b/packages/lib/har/harUtils.ts
@@ -101,10 +101,6 @@ export const checkMimeTypeListAndParseBody = (
   body: string | Buffer,
   mimeType?: string,
 ): HarFormatPostData => {
-  const defaultTextReturn = {
-    mimeType: mimeType ?? '',
-    text: body.toString('binary'),
-  };
   if (
     (mimeType && parseMimeTypesAsJson.includes(mimeType)) ||
     (!mimeType && parseMimeTypesAsJson.includes(''))
@@ -114,11 +110,12 @@ export const checkMimeTypeListAndParseBody = (
         mimeType,
         json: JSON.parse(body.toString('utf-8')),
       };
-    } catch (error) {
-      return defaultTextReturn;
-    }
+    } catch (error) {}
   }
-  return defaultTextReturn;
+  return {
+    mimeType: mimeType ?? '',
+    text: body.toString('binary'),
+  };
 };
 
 export const toHarPostData = (

--- a/packages/lib/har/harUtils.ts
+++ b/packages/lib/har/harUtils.ts
@@ -96,7 +96,7 @@ export const fromHarContent = (content?: HarFormatContent) => {
   return Buffer.alloc(0);
 };
 
-const checkMimeTypeListAndParseBody = (
+export const checkMimeTypeListAndParseBody = (
   parseMimeTypesAsJson: string[],
   body: string | Buffer,
   mimeType?: string,


### PR DESCRIPTION
A new configuration option has been added, `saveStringBodies`, which is set to true by default. This can be changed with the new `setSaveStringBodies` method. A new parameter has been added to `toHarPostData` and `toHarContent` where `saveStringBodies` will be passed in.

When `saveStringBodies` is set to false and the **mimeType** of the request/response is application/json the body will be json parsed and saved. 

This will only be applied when the `mockFormat` is 'HAR'.
This will be applied to both request (when `saveInputRequestBody` is true) and response bodies.